### PR TITLE
Major changes to face desc saving and getting methods

### DIFF
--- a/server/config/interface.ts
+++ b/server/config/interface.ts
@@ -50,4 +50,5 @@ export interface IStudent extends Document {
 
 export interface ILabledFaceDescriptor extends Document {
     label?: string
+    descriptors: [[number]]
 }

--- a/server/controllers/faceControllers.ts
+++ b/server/controllers/faceControllers.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from 'express'
 import { ILabledFaceDescriptor } from '../config/interface'
+import labledFaceDescriptorsModel from '../models/labledFaceDescriptorsModel'
+import mongoose from 'mongoose'
 import fs from 'fs'
 import path from 'path'
 
@@ -21,16 +23,74 @@ export const saveLabledFaceDescriptors = async (req: Request, res: Response) => 
 
 export const saveLabledFaceDescriptors_guest = async (req: Request, res: Response) => {
     try {
+        console.log(req.body);
         const data: ILabledFaceDescriptor = req.body;
+        console.log(data);
+
+        // Luu len MongoDB
+        let newLabeldFaceDesc = new labledFaceDescriptorsModel(data);
+        newLabeldFaceDesc = await newLabeldFaceDesc.save()
 
         // Luu file json
         const pathFile = `${__dirname}/../descriptors/${data.label}.json`
         fs.writeFileSync(pathFile, JSON.stringify(data))
 
-        return res.json({ msg: "Lưu model thành công" })
+        return res.json({ 
+            msg: "Lưu model thành công",
+            //data: data._doc
+        })
 
     } catch (error: any) {
         console.log(error.message)
+        return res.status(500).json({ msg: error.message })
+    }
+}
+
+/// purely test func to test API responses and MongoDB data transferring
+export const getDescriptors_guest = async (req: Request, res: Response) => {
+    try {
+
+        //const { studentCodeList } = req.body;
+        const studentCodeList  = ["B2Tuan Tu", "B3Tuan Tu"];
+        const normalDesc = [[2, 3, 4], [5, 6, 7]];
+
+        const dir = `${__dirname}/../descriptors`
+
+        const data = await fs.readdirSync(dir)
+            // .filter(filename => {
+            //     var file = path.basename(filename, path.extname(filename));
+            //     return file === studentCodeList.find((studentCode: any) => {
+            //         return studentCode.toLowerCase() === file.toLowerCase()
+            //     })
+            // })
+            .map(name => require(path.join(dir, name)))
+        //const mongo_data = await labledFaceDescriptorsModel.find({label: {$in: studentCodeList}}, {label: 1, descriptors: 1, _id: 0})
+        const mongo_data = await labledFaceDescriptorsModel.find({label: {$in: studentCodeList}}, {label: "$label", descriptors: "$descriptors", _id: 0})
+        //const mongo_data = await labledFaceDescriptorsModel.find({label: {$in: studentCodeList}}, { descriptors: "$descriptors", label: "$label", _id: 0})
+        
+        // find test
+        //const mongo_data2 = await labledFaceDescriptorsModel.find({"label": "B3Tuan Tu"})
+        // let mongo_data2 = await labledFaceDescriptorsModel.find({"label": "B2Tuan Tu"})
+        // // It's always going to be true btw
+        // if (mongo_data2) {
+        //     console.log('Initial data: ', mongo_data2)
+        //     // push another number array with value [2]
+        //     await labledFaceDescriptorsModel.updateOne({"label": "B2Tuan Tu"}, {$push: {descriptors: {$each: normalDesc}}}, {new: true})
+        // }
+        // else {
+        //     console.log("Data does not exist");
+        // }
+        //console.log('Updated data: ', mongo_data2)
+        // Well if you dont grab it again or set option {new: true}(?) how are you going to 
+        // print the latest value
+
+        // upsert test
+        //await labledFaceDescriptorsModel.updateOne({"label": "B4Tuan Tu"}, {$set: {label: "B4Tuan Tu"}, $push: {descriptors: {$each: normalDesc}}}, {upsert: true})
+        // it works but the desc field is reordered in MongoDB Atlas, since the size of the desc field is changed every time this happens
+
+        return res.json({ descriptors: mongo_data, msg: "Lấy các descriptors thành công" })
+
+    } catch (error: any) {
         return res.status(500).json({ msg: error.message })
     }
 }
@@ -52,6 +112,71 @@ export const getDescriptors = async (req: Request, res: Response) => {
             .map(name => require(path.join(dir, name)))
 
         return res.json({ descriptors: data, msg: "Lấy các descriptors thành công" })
+
+    } catch (error: any) {
+        return res.status(500).json({ msg: error.message })
+    }
+}
+
+/// funcs to work with mongoDB
+export const saveLabledFaceDescriptors_DB_guest = async (req: Request, res: Response) => {
+    try {
+        console.log(req.body);
+        const data: ILabledFaceDescriptor = req.body;
+        console.log(data);
+
+        // Luu len MongoDB
+        //if ((await labledFaceDescriptorsModel.find({"label": data.label})).length !== 0)
+        //let newLabeldFaceDesc = new labledFaceDescriptorsModel(data);
+        //newLabeldFaceDesc = await newLabeldFaceDesc.save();
+
+        await labledFaceDescriptorsModel.updateOne({"label": data.label},
+                                                    //{$set: {label: data.label}, $push: {descriptors: data.descriptors[0]}},
+                                                    {$set: {label: data.label}, $push: {descriptors: {$each: data.descriptors}}},
+                                                    {upsert: true}
+        )
+
+        return res.json({ 
+            msg: "Lưu model thành công",
+        })
+
+    } catch (error: any) {
+        console.log(error.message)
+        return res.status(500).json({ msg: error.message })
+    }
+}
+export const saveLabledFaceDescriptors_DB = async (req: Request, res: Response) => {
+    try {
+        //console.log(req.body);
+        const data: ILabledFaceDescriptor = req.body;
+        //console.log(data);
+
+        // Luu len MongoDB
+        //if ((await labledFaceDescriptorsModel.find({"label": data.label})).length !== 0)
+        //let newLabeldFaceDesc = new labledFaceDescriptorsModel(data);
+        //newLabeldFaceDesc = await newLabeldFaceDesc.save();
+
+        await labledFaceDescriptorsModel.updateOne({"label": data.label},
+                                                    {$set: {label: data.label, descriptors: data.descriptors}},
+                                                    {upsert: true}
+        )
+
+        return res.json({ 
+            msg: "Lưu model thành công",
+        })
+
+    } catch (error: any) {
+        console.log(error.message)
+        return res.status(500).json({ msg: error.message })
+    }
+}
+export const getDescriptors_DB = async (req: Request, res: Response) => {
+    try {
+
+        const { studentCodeList } = req.body;
+        const mongo_data = await labledFaceDescriptorsModel.find({label: {$in: studentCodeList}}, {label: 1, descriptors: 1, _id: 0})
+        console.log(mongo_data);
+        return res.json({ descriptors: mongo_data, msg: "Lấy các descriptors thành công" })
 
     } catch (error: any) {
         return res.status(500).json({ msg: error.message })

--- a/server/models/labledFaceDescriptorsModel.ts
+++ b/server/models/labledFaceDescriptorsModel.ts
@@ -7,6 +7,7 @@ const LabledFaceDescriptorScheme = new mongoose.Schema({
         type: String,
         trim: true
     },
+    descriptors: [[Number]]
 }, {
     timestamps: true
 })

--- a/server/routers/faceRouters.ts
+++ b/server/routers/faceRouters.ts
@@ -1,13 +1,14 @@
 
 import express from 'express'
-import { saveLabledFaceDescriptors, saveLabledFaceDescriptors_guest, getDescriptors } from '../controllers/faceControllers'
+import { saveLabledFaceDescriptors, saveLabledFaceDescriptors_guest, getDescriptors_DB, getDescriptors_guest, saveLabledFaceDescriptors_DB, saveLabledFaceDescriptors_DB_guest } from '../controllers/faceControllers'
 
 import { auth } from '../middlewares/auth'
 
 const router = express.Router();
-router.post('/face_api', auth, saveLabledFaceDescriptors);
-router.post('/face_api_guest', saveLabledFaceDescriptors_guest);
-router.post('/face_api_descriptors', auth, getDescriptors);
+router.post('/face_api', auth, saveLabledFaceDescriptors_DB);
+router.post('/face_api_guest', saveLabledFaceDescriptors_DB_guest);
+router.post('/face_api_descriptors', auth, getDescriptors_DB);
+router.get('/face_api_descriptors_guest', getDescriptors_guest);
 
 
 export default router;


### PR DESCRIPTION
- Added a descriptor: [[number]] interface for interface.ts and labeledFaceDescModel.
- Modified most Face desc. saving and getting methods to work with the current Mongo Cloud Database, this helps with deployment.
- Modified faceRouters.ts, changing most APIs to their new methods while still keeping older ones for testing purposes.
(Khi build web service, nó chỉ sẽ lấy trong file của repo. Khi web service tắt thì build cũng sẽ mất theo => Các file desc được tạo sau các file desc của repo sẽ mất vì chúng không được commit lên, nhưng ta cũng không thể nào để người dùng commit file desc của họ lên repo của mình được => Yêu cầu chuyển các file desc lên 1 cloud database để lưu trữ).